### PR TITLE
fix panic when loading malformed torrent

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -162,6 +162,12 @@ func (e *Engine) NewTorrentBySpec(spec *torrent.TorrentSpec) error {
 
 // NewTorrentByFilePath -> NewTorrentBySpec
 func (e *Engine) NewTorrentByFilePath(path string) error {
+    defer func() error {
+        if r := recover(); r != nil {
+            return fmt.Errorf("Error loading new torrent from file %s: %+v", path, r)
+        }
+        return nil
+    }()
 	info, err := metainfo.LoadFromFile(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
torrent.TorrentSpecFromMetaInfo() may panic when saved torrent is malformed, causing the service not usable after restart.

following the panic log

<pre>
goroutine 29 [running]:
github.com/anacrolix/torrent.TorrentSpecFromMetaInfo(0xc000248000, 0x5f)
    github.com/anacrolix/torrent@v1.25.1/spec.go:52 +0x405
github.com/jpillora/cloud-torrent/engine.(*Engine).NewTorrentByFilePath(0xc000212c80, 0xc000082120, 0x5f, 0x2, 0x2)
    github.com/jpillora/cloud-torrent@v0.0.0-20180427161701-1a741e3d8dd2/engine/engine.go:177 +0x6d
github.com/jpillora/cloud-torrent/server.(*Server).RestoreTorrent(0xc000055800, 0xc000082540, 0x51)
    github.com/jpillora/cloud-torrent@v0.0.0-20180427161701-1a741e3d8dd2/server/server_bg.go:79 +0x1d4
created by github.com/jpillora/cloud-torrent/server.(*Server).backgroundRoutines
    github.com/jpillora/cloud-torrent@v0.0.0-20180427161701-1a741e3d8dd2/server/server_bg.go:67 +0x110
</pre>